### PR TITLE
Fix pod config by copying Realm multiplatform demo setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,22 +1,21 @@
-buildscript {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-        google()
-    }
-    dependencies {
-        classpath("io.realm.kotlin:gradle-plugin:1.6.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
-        classpath("com.android.tools.build:gradle:7.2.1")
-    }
+plugins {
+    kotlin("multiplatform") version "1.7.20" apply false
+    id("com.android.library") version "7.3.0" apply false
 }
 
-allprojects {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-        google()
+// Explicitly adding the plugin to the classpath as it makes it easier to control the version
+// centrally (don't need version in the 'plugins' block). Further, snapshots are not published with
+// marker interface so would need to be added to the classpath manually anyway.
+buildscript {
+    dependencies {
+        classpath("io.realm.kotlin:gradle-plugin:1.6.0")
     }
+}
+rootProject.extra["realmVersion"] = "1.6.0"
+
+allprojects {
+    group = "io.realm.sample"
+    version = "1.0.0"
 }
 
 tasks.register("clean", Delete::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,38 +1,9 @@
-## For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-#
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx1024m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-#
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-#Fri May 10 11:34:39 CEST 2019
+#Gradle
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 
-org.gradle.jvmargs=-Xmx4096m -Xmx8192m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.parallel=true
-org.gradle.caching=true
-
-kapt.use.worker.api=true
-kapt.include.compile.classpath=false
-kotlin.parallel.tasks.in.project = true
+#Kotlin
 kotlin.code.style=official
-kotlin.native.cacheKind.iosX64=none
-kotlin.native.binary.memoryModel=experimental
+kotlin.mpp.stability.nowarn=true
 
-android.injected.testOnly=false
-android.enableJetifier=true
+#Android
 android.useAndroidX=true
-android.bundle.enableUncompressedNativeLibs = false
-
-
-AUSTRIA_VERSIONNAME=7.8.2
-FRANCE_VERSIONNAME=7.8.2
-GERMANY_VERSIONNAME=7.8.2
-SWITZERLAND_VERSIONNAME=7.8.2
-AE_VERSIONNAME=7.8.2
-UK_VERSIONNAME=7.8.2
-IRELAND_VERSIONNAME=7.8.2

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Realm (10.28.7):
-    - Realm/Headers (= 10.28.7)
-  - Realm/Headers (10.28.7)
-  - RealmSwift (10.28.7):
-    - Realm (= 10.28.7)
+  - Realm (10.36.0):
+    - Realm/Headers (= 10.36.0)
+  - Realm/Headers (10.36.0)
+  - RealmSwift (10.36.0):
+    - Realm (= 10.36.0)
 
 DEPENDENCIES:
   - RealmSwift
@@ -14,8 +14,8 @@ SPEC REPOS:
     - RealmSwift
 
 SPEC CHECKSUMS:
-  Realm: d1d5ad078b9c1d22f99f7f7f2e692b548b518f24
-  RealmSwift: 7c38e0acca7d3df9cc60d79c073ef68245351d0e
+  Realm: 3fd136cb4c83a927482a7f1612496d37beed3cf5
+  RealmSwift: 513d4dcbf5bfc4d573454088b592685fc48dd716
 
 PODFILE CHECKSUM: 5330cbdeddb04506fa3f55bf5a5349c06cde577f
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00867E979CB2627BE4104B04 /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FCBD3DA7A694FA3EF747A85 /* Pods_iosApp.framework */; };
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
-		8E209A7122CA36046B58E47C /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FAB393C16FEB3CB48534B43 /* Pods_iosApp.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,12 +31,12 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		2E55F0771E7C5C6B97C37EEA /* Pods-iosApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debug.xcconfig"; sourceTree = "<group>"; };
+		3FCBD3DA7A694FA3EF747A85 /* Pods_iosApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		64083D7E844A8E62A064B31A /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8EF6FC778222A8A716A03D7C /* Pods-iosApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debug.xcconfig"; sourceTree = "<group>"; };
-		8FAB393C16FEB3CB48534B43 /* Pods_iosApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B0B1E16929CB9A0CA0A0A884 /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -44,7 +44,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8E209A7122CA36046B58E47C /* Pods_iosApp.framework in Frameworks */,
+				00867E979CB2627BE4104B04 /* Pods_iosApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,8 +64,8 @@
 			children = (
 				7555FF7D242A565900829871 /* iosApp */,
 				7555FF7C242A565900829871 /* Products */,
-				7555FFB0242A642200829871 /* Frameworks */,
 				B487E361B8D23147C900AA32 /* Pods */,
+				A38A5A6327C5CBB4F44EE8AB /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -89,10 +89,10 @@
 			path = iosApp;
 			sourceTree = "<group>";
 		};
-		7555FFB0242A642200829871 /* Frameworks */ = {
+		A38A5A6327C5CBB4F44EE8AB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8FAB393C16FEB3CB48534B43 /* Pods_iosApp.framework */,
+				3FCBD3DA7A694FA3EF747A85 /* Pods_iosApp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -100,8 +100,8 @@
 		B487E361B8D23147C900AA32 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8EF6FC778222A8A716A03D7C /* Pods-iosApp.debug.xcconfig */,
-				B0B1E16929CB9A0CA0A0A884 /* Pods-iosApp.release.xcconfig */,
+				2E55F0771E7C5C6B97C37EEA /* Pods-iosApp.debug.xcconfig */,
+				64083D7E844A8E62A064B31A /* Pods-iosApp.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -113,13 +113,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
 			buildPhases = (
-				0510200B4EBACEF424F87946 /* [CP] Check Pods Manifest.lock */,
+				E7DEE31EE044CBDBDEAD9C3E /* [CP] Check Pods Manifest.lock */,
 				7555FFB5242A651A00829871 /* ShellScript */,
 				7555FF77242A565900829871 /* Sources */,
 				7555FF78242A565900829871 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
 				7555FFB4242A642300829871 /* Embed Frameworks */,
-				A040E06806C75DF5C7F74263 /* [CP] Embed Pods Frameworks */,
+				36090CC44CC49457AC3E9B08 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -176,7 +176,41 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0510200B4EBACEF424F87946 /* [CP] Check Pods Manifest.lock */ = {
+		36090CC44CC49457AC3E9B08 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7555FFB5242A651A00829871 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignPodAppleFrameworkForXcode\n";
+		};
+		E7DEE31EE044CBDBDEAD9C3E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -196,40 +230,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7555FFB5242A651A00829871 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
-		};
-		A040E06806C75DF5C7F74263 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -365,7 +365,7 @@
 		};
 		7555FFA6242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8EF6FC778222A8A716A03D7C /* Pods-iosApp.debug.xcconfig */;
+			baseConfigurationReference = 2E55F0771E7C5C6B97C37EEA /* Pods-iosApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -395,7 +395,7 @@
 		};
 		7555FFA7242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B0B1E16929CB9A0CA0A0A884 /* Pods-iosApp.release.xcconfig */;
+			baseConfigurationReference = 64083D7E844A8E62A064B31A /* Pods-iosApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,24 @@
+
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+        maven(url = "https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        // Only required for realm-kotlin snapshots
+        maven("https://oss.sonatype.org/content/repositories/snapshots")
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        // Only required for realm-kotlin snapshots
+        maven("https://oss.sonatype.org/content/repositories/snapshots")
+    }
+}
+
 rootProject.name = "My_Application"
 include(":androidApp")
 include(":shared")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,27 +1,41 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     kotlin("multiplatform")
+    kotlin("native.cocoapods")
     id("com.android.library")
     id("io.realm.kotlin")
 }
 
 kotlin {
     android()
-    
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "shared"
-        }
+
+    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget = when {
+        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true -> ::iosArm64
+        System.getenv("NATIVE_ARCH")?.startsWith("arm") == true -> ::iosSimulatorArm64
+        else -> ::iosX64
+    }
+    iosTarget("ios") {}
+
+    val macosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget = when {
+        System.getenv("NATIVE_ARCH")?.startsWith("arm") == true -> ::macosArm64
+        else -> ::macosX64
+    }
+    macosTarget("macos") {}
+
+    cocoapods {
+        summary = "Realm Kotlin Multiplatform Demo Shared Library"
+        homepage = "https://github.com/realm/realm-kotlin"
+        ios.deploymentTarget = "14.1"
+        osx.deploymentTarget = "11.0"
+        frameworkName = "shared"
     }
 
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api("io.realm.kotlin:library-base:1.6.0")
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+                implementation("io.realm.kotlin:library-base:1.6.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }
         }
         val commonTest by getting {
@@ -31,24 +45,11 @@ kotlin {
         }
         val androidMain by getting
         val androidTest by getting
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosSimulatorArm64Main by getting
-        val iosMain by creating {
-            dependsOn(commonMain)
-            iosX64Main.dependsOn(this)
-            iosArm64Main.dependsOn(this)
-            iosSimulatorArm64Main.dependsOn(this)
-        }
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosSimulatorArm64Test by getting
-        val iosTest by creating {
-            dependsOn(commonTest)
-            iosX64Test.dependsOn(this)
-            iosArm64Test.dependsOn(this)
-            iosSimulatorArm64Test.dependsOn(this)
-        }
+
+        val iosMain by getting
+        val iosTest by getting
+        val macosMain by getting
+        val macosTest by getting
     }
 }
 


### PR DESCRIPTION
Fixes an issue of Pods not loading the Realm resources property by replacing the gradle setup with the one used in[Realm Multiplatform demo](https://github.com/realm/realm-kotlin-samples/tree/main/MultiplatformDemo).